### PR TITLE
Fix for swift4

### DIFF
--- a/SystemProfilerPlayground.playground/Sources/Utility.swift
+++ b/SystemProfilerPlayground.playground/Sources/Utility.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public func timeMe(label: String, code :(Void) -> Void ) {
+public func timeMe(label: String, code :() -> Void ) {
     let fortimeAtStart = Date()
     code()
     let forelapsedtime = Date()


### PR DESCRIPTION

The special "Void" return type is represented by an empty tuple: ().